### PR TITLE
task/enable-releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ permissions:
   contents: write
 
 on:
+  workflow_dispatch: {}
   push:
     tags:
       - v[0-9]+.*


### PR DESCRIPTION
I want to enable releases so we can easily grab the binary to run flight management correctly. I can't run the int tests without it

[Work item](https://airspacelink.monday.com/boards/8467704246/pulses/9387009188)